### PR TITLE
Add link to RailsBridge curriculum

### DIFF
--- a/source/views/_bar.html.haml
+++ b/source/views/_bar.html.haml
@@ -12,4 +12,4 @@
       = nav_link "About", "/", class: "nav-link"
       = nav_link "Schedule", "/schedule", class: "nav-link"
       = nav_link "Resources", "/resources", class: "nav-link"
-      = nav_link "Curriculum", "#", class: "nav-link"
+      = nav_link "Curriculum", "http://docs.railsbridge.org/docs/", class: "nav-link"


### PR DESCRIPTION
We're not planning on forking the curriculum so we might as well link to
the main RailsBridge curriculum from our site.