### PR TITLE
Add current events page to redirect to the signup

### DIFF
--- a/source/views/current_event.html.erb
+++ b/source/views/current_event.html.erb
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <meta http-equiv=refresh content="0; url=<%= signup_url %>" />
+    <meta name="robots" content="noindex,follow" />
+    <meta http-equiv="cache-control" content="no-cache" />
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
This allows us to use one single URL that still goes through our domain for
signups.